### PR TITLE
Add input and ouput from QueryIOMetadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <version>1.9</version>
+    <version>2.0</version>
     <groupId>com.shopify.presto</groupId>
 
     <artifactId>logging-plugin</artifactId>

--- a/src/main/java/com/shopify/presto/eventlisteners/QueryLogEventListener.java
+++ b/src/main/java/com/shopify/presto/eventlisteners/QueryLogEventListener.java
@@ -80,6 +80,8 @@ public class QueryLogEventListener implements EventListener
         queryEventJson.put("query_status", queryFailed ? "FAILURE" : "SUCCESS");
         queryEventJson.put("failure_message", queryFailed ? queryCompletedEvent.getFailureInfo().get().getErrorCode().getName() : null);
         queryEventJson.put("user", queryCompletedEvent.getContext().getUser());
+        queryEventJson.put("inputs", queryCompletedEvent.getIoMetadata().getInputs());
+        queryEventJson.put("output", queryCompletedEvent.getIoMetadata().getOutput());
         queryEventJson.put("event_timestamp", getCurrentTimeStamp(sdf));
 
         log.debug("Sending " + queryEventJson.toString() + " to Kafka Topic: " + TOPIC_NAME);

--- a/src/main/java/com/shopify/presto/eventlisteners/QueryLogEventListener.java
+++ b/src/main/java/com/shopify/presto/eventlisteners/QueryLogEventListener.java
@@ -77,6 +77,7 @@ public class QueryLogEventListener implements EventListener
         queryEventJson.put("end_time", queryCompletedEvent.getEndTime().toString());
         queryEventJson.put("queued_time", queryCompletedEvent.getStatistics().getQueuedTime().getSeconds());
         queryEventJson.put("query_text", queryCompletedEvent.getMetadata().getQuery());
+        queryEventJson.put("field_names", queryCompletedEvent.getIoMetadata().getFieldNames());
         queryEventJson.put("query_status", queryFailed ? "FAILURE" : "SUCCESS");
         queryEventJson.put("failure_message", queryFailed ? queryCompletedEvent.getFailureInfo().get().getErrorCode().getName() : null);
         queryEventJson.put("user", queryCompletedEvent.getContext().getUser());

--- a/src/main/java/com/shopify/presto/eventlisteners/QueryLogEventListener.java
+++ b/src/main/java/com/shopify/presto/eventlisteners/QueryLogEventListener.java
@@ -77,7 +77,6 @@ public class QueryLogEventListener implements EventListener
         queryEventJson.put("end_time", queryCompletedEvent.getEndTime().toString());
         queryEventJson.put("queued_time", queryCompletedEvent.getStatistics().getQueuedTime().getSeconds());
         queryEventJson.put("query_text", queryCompletedEvent.getMetadata().getQuery());
-        queryEventJson.put("field_names", queryCompletedEvent.getIoMetadata().getFieldNames());
         queryEventJson.put("query_status", queryFailed ? "FAILURE" : "SUCCESS");
         queryEventJson.put("failure_message", queryFailed ? queryCompletedEvent.getFailureInfo().get().getErrorCode().getName() : null);
         queryEventJson.put("user", queryCompletedEvent.getContext().getUser());


### PR DESCRIPTION
**NOTE: I don't know how to test this**

**Why?**
Rather than parsing Presto queries, I figured we could let Presto tell us which inputs are being used, and what the output columns are. 

I'm using [TestEventListener.java](https://github.com/prestodb/presto/blob/1c0ae7c92e4f2fe3599730b22fc84066cbd746a4/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java#L140-L141) as the basis for these changes.

Thoughts? Is this OK to do?