### PR TITLE
Add logic to parse Presto tables and operation from logged queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,19 @@
             <artifactId>log</artifactId>
             <version>0.139</version>
         </dependency>
-        <!-- Presto SPI -->
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
             <scope>provided</scope>
-            <version>0.164</version>
+            <version>0.198</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-parser</artifactId>
+            <scope>provided</scope>
+            <version>0.198</version>
         </dependency>
 
         <dependency>
@@ -37,6 +44,11 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20160810</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>RELEASE</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/shopify/presto/eventlisteners/AstTableVisitor.java
+++ b/src/main/java/com/shopify/presto/eventlisteners/AstTableVisitor.java
@@ -1,0 +1,120 @@
+package com.shopify.presto.eventlisteners;
+
+import com.facebook.presto.sql.tree.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+class AstTableVisitor extends DefaultTraversalVisitor<Object, AstTableVisitor.TableVisitorContext> {
+
+    /**
+     * Visit every table reference and add them to a set. Find any CTE definitions so we can remove them
+     * from the list of actual tables that are referenced. It's not possible to distinguish views from
+     * tables just by parsing the query, we just treat everything as a "table".
+     */
+
+    @Override
+    protected Object visitTable(Table node, TableVisitorContext context) {
+        context.addFromTable(node.getName().getSuffix());
+        return super.visitTable(node, context);
+    }
+
+    @Override
+    protected Object visitAliasedRelation(AliasedRelation node, TableVisitorContext context)
+    {
+        context.addAliasTable(node.getAlias().getValue());
+        return process(node.getRelation(), context);
+    }
+
+    @Override
+    protected Object visitInsert(Insert node, TableVisitorContext context)
+    {
+        context.setTargetTable(node.getTarget().getSuffix());
+        super.visitInsert(node, context);
+        return null;
+    }
+
+    @Override
+    protected Object visitQuerySpecification(QuerySpecification node, TableVisitorContext context) {
+        super.visitQuerySpecification(node, context);
+        return null;
+    }
+
+    @Override
+    protected Object visitWithQuery(WithQuery node, TableVisitorContext context)
+    {
+        context.addCTETable(node.getName().getValue());
+        super.visitWithQuery(node, context);
+        return null;
+    }
+
+    @Override
+    protected Object visitCreateTable(CreateTable node, TableVisitorContext context)
+    {
+        context.setTargetTable(node.getName().getSuffix());
+        super.visitCreateTable(node, context);
+        return null;
+    }
+
+    @Override
+    protected Object visitCreateView(CreateView node, TableVisitorContext context)
+    {
+        context.setTargetTable(node.getName().getSuffix());
+        super.visitCreateView(node, context);
+        return null;
+    }
+
+    @Override
+    protected Object visitDropTable(DropTable node, TableVisitorContext context)
+    {
+        context.setTargetTable(node.getTableName().getSuffix());
+        super.visitDropTable(node, context);
+        return null;
+    }
+
+    @Override
+    protected Object visitDropView(DropView node, TableVisitorContext context)
+    {
+        context.setTargetTable(node.getName().getSuffix());
+        super.visitDropView(node, context);
+        return null;
+    }
+
+    @Override
+    protected Object visitCreateTableAsSelect(CreateTableAsSelect node, TableVisitorContext context)
+    {
+        context.setTargetTable(node.getName().getSuffix());
+        super.visitCreateTableAsSelect(node, context);
+        return null;
+    }
+
+    static class TableVisitorContext {
+        Set<String> fromTables;
+        Set<String> cteTables;
+        Set<String> aliasTables;
+        String targetTable;
+
+        TableVisitorContext() {
+            fromTables = new HashSet<>();
+            aliasTables = new HashSet<>();
+            cteTables = new HashSet<>();
+            targetTable = "";
+        }
+
+        public void addFromTable(String table) {
+            fromTables.add(table);
+        }
+
+        public void addAliasTable(String table) {
+            aliasTables.add(table);
+        }
+
+        public void setTargetTable(String table) {
+            targetTable = table;
+        }
+
+        public void addCTETable(String table) {
+            cteTables.add(table);
+        }
+    }
+}

--- a/src/main/java/com/shopify/presto/eventlisteners/QueryDetails.java
+++ b/src/main/java/com/shopify/presto/eventlisteners/QueryDetails.java
@@ -1,0 +1,73 @@
+package com.shopify.presto.eventlisteners;
+
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.*;
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+public class QueryDetails {
+    private String queryText;
+
+    // The table or view to be created/dropped/modified/inserted into if there is one
+    private String targetTable;
+
+    // Tables or views in the from part of the query
+    private Set<String> fromTables;
+
+    // Tables defined in CTEs
+    private Set<String> cteTables;
+
+    // Table aliases
+    private Set<String> aliasTables;
+
+    private String operation;
+
+    private QueryDetails(String queryText, String targetTable, Set<String> fromTables, Set<String> cteTables, Set<String> aliasTables,  String operation) {
+        this.queryText = queryText;
+        this.targetTable = targetTable;
+        this.fromTables = fromTables;
+        this.cteTables = cteTables;
+        this.aliasTables = aliasTables;
+        this.operation = operation;
+    }
+
+    public String getQueryText() {
+        return queryText;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public Set<String> getFromTables() {
+        return fromTables;
+    }
+
+    public String getTargetTable() {
+        return targetTable;
+    }
+
+    public Set<String> getCTETables() {
+        return cteTables;
+    }
+
+    public Set<String> getAliasTables() {
+        return aliasTables;
+    }
+
+    public Set<String> getFromTablesWithoutCTEs() {
+        return Sets.difference(fromTables, cteTables);
+    }
+
+    public static QueryDetails parseQueryDetails(String queryText) {
+        SqlParser parser = new SqlParser();
+        Statement stmt = parser.createStatement(queryText, new ParsingOptions());
+        String operation = stmt.getClass().getSimpleName();
+        AstTableVisitor v = new AstTableVisitor();
+        AstTableVisitor.TableVisitorContext ctx = new AstTableVisitor.TableVisitorContext();
+        stmt.accept(v, ctx);
+        return new QueryDetails(queryText, ctx.targetTable, ctx.fromTables, ctx.cteTables, ctx.aliasTables, operation);
+    }
+}

--- a/src/test/java/com/shopify/presto/eventlistener/TestQueryDetails.java
+++ b/src/test/java/com/shopify/presto/eventlistener/TestQueryDetails.java
@@ -1,0 +1,123 @@
+package com.shopify.presto.eventlistener;
+
+import com.shopify.presto.eventlisteners.QueryDetails;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestQueryDetails {
+
+    @Test
+    public void testParseSelectSimple() {
+        QueryDetails d = QueryDetails.parseQueryDetails("SELECT * FROM t1");
+        assertEquals( newHashSet("t1"), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals("", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
+        assertEquals("Query", d.getOperation());
+    }
+
+    @Test
+    public void testParseSelectSubquery() {
+        QueryDetails d = QueryDetails.parseQueryDetails("SELECT * FROM t1, (SELECT a, b FROM t2)");
+        assertEquals(newHashSet("t1", "t2"), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals("", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
+        assertEquals("Query", d.getOperation());
+    }
+
+    @Test
+    public void testParseSelectSubqueryWithAlias() {
+        QueryDetails d = QueryDetails.parseQueryDetails("SELECT * FROM t1, (SELECT a, b FROM t2) x");
+        assertEquals(newHashSet("t1", "t2"), d.getFromTables());
+        assertEquals(newHashSet("x"), d.getAliasTables());
+        assertEquals("", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
+        assertEquals("Query", d.getOperation());
+    }
+
+    @Test
+    public void testParseJoin() {
+        QueryDetails d = QueryDetails.parseQueryDetails("SELECT * FROM t1 as y JOIN (SELECT a, b FROM t2) x ON (x.a = y.a)");
+        assertEquals(newHashSet("t1", "t2"), d.getFromTables());
+        assertEquals(newHashSet("x", "y"), d.getAliasTables());
+        assertEquals("", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
+        assertEquals("Query", d.getOperation());
+    }
+
+    @Test
+    public void testParseSelectCTE() {
+        QueryDetails d = QueryDetails.parseQueryDetails("WITH x as (SELECT a, b FROM t2) SELECT * FROM t1 JOIN x ON (e.a = t1.a) ");
+        assertEquals(newHashSet("t1", "t2", "x"), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals("", d.getTargetTable());
+        assertEquals(newHashSet("x"), d.getCTETables());
+        assertEquals("Query", d.getOperation());
+        assertEquals(newHashSet("t1", "t2"), d.getFromTablesWithoutCTEs());
+    }
+
+    @Test
+    public void testParseInsertSimple() {
+        QueryDetails d = QueryDetails.parseQueryDetails("INSERT INTO t2 SELECT * FROM t1");
+        assertEquals(newHashSet("t1"), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals("t2", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
+        assertEquals("Insert", d.getOperation());
+    }
+
+    @Test
+    public void testParseCreateTable() {
+        QueryDetails d = QueryDetails.parseQueryDetails("CREATE TABLE x (c1 VARCHAR)");
+        assertEquals(Collections.emptySet(), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals( "x", d.getTargetTable());
+        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("CreateTable", d.getOperation());
+    }
+
+    @Test
+    public void testParseCreateTableAsSelect() {
+        QueryDetails d = QueryDetails.parseQueryDetails("CREATE TABLE x AS SELECT * FROM y");
+        assertEquals(newHashSet("y"), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals( "x", d.getTargetTable());
+        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("CreateTableAsSelect", d.getOperation());
+    }
+
+    @Test
+    public void testParseCreateView() {
+        QueryDetails d = QueryDetails.parseQueryDetails("CREATE VIEW x AS SELECT * FROM y");
+        assertEquals(newHashSet("y"), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals( "x", d.getTargetTable());
+        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("CreateView", d.getOperation());
+    }
+
+    @Test
+    public void testParseDropTable() {
+        QueryDetails d = QueryDetails.parseQueryDetails("DROP TABLE x");
+        assertEquals(Collections.emptySet(), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals( "x", d.getTargetTable());
+        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("DropTable", d.getOperation());
+    }
+
+    @Test
+    public void testParseDropView() {
+        QueryDetails d = QueryDetails.parseQueryDetails("DROP VIEW x");
+        assertEquals(Collections.emptySet(), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals( "x", d.getTargetTable());
+        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("DropView", d.getOperation());
+    }
+}


### PR DESCRIPTION
Add three new fields to Presto query logs:
- `query_operation` - the type of query ex. Select, Insert, DropTable, CreateTable
- `query_from_tables` - an array of source tables for select queries. We do some parsing to remove CTEs from this list, so it should contain only real table and view names without catalog or schema name
- `query_target_table` - the target of an Insert, DropTable or CreateTable operation

Putting these into the Presto logs table will let us answer some more interesting questions about our workload:
- "popularity" of tables in terms of number of queries or CPU time, wall time, etc. spent querying
- whether there are tables which are never queried
- whether Presto/Hive bugs are causing failures on specific tables
- audit history of table creation and drops

This can all be done at query time with a complicated regex now, but actually parsing the queries means we handle CTEs, aliases, etc. better.