### PR TITLE
Add support for decimal literals

### DIFF
--- a/src/main/java/com/shopify/presto/eventlisteners/QueryDetails.java
+++ b/src/main/java/com/shopify/presto/eventlisteners/QueryDetails.java
@@ -63,7 +63,7 @@ public class QueryDetails {
 
     public static QueryDetails parseQueryDetails(String queryText) {
         SqlParser parser = new SqlParser();
-        Statement stmt = parser.createStatement(queryText, new ParsingOptions());
+        Statement stmt = parser.createStatement(queryText, new ParsingOptions(ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL));
         String operation = stmt.getClass().getSimpleName();
         AstTableVisitor v = new AstTableVisitor();
         AstTableVisitor.TableVisitorContext ctx = new AstTableVisitor.TableVisitorContext();

--- a/src/test/java/com/shopify/presto/eventlistener/TestQueryDetails.java
+++ b/src/test/java/com/shopify/presto/eventlistener/TestQueryDetails.java
@@ -13,7 +13,7 @@ public class TestQueryDetails {
     @Test
     public void testParseSelectSimple() {
         QueryDetails d = QueryDetails.parseQueryDetails("SELECT * FROM t1");
-        assertEquals( newHashSet("t1"), d.getFromTables());
+        assertEquals(newHashSet("t1"), d.getFromTables());
         assertEquals(Collections.emptySet(), d.getAliasTables());
         assertEquals("", d.getTargetTable());
         assertEquals(Collections.emptySet(), d.getCTETables());
@@ -76,8 +76,8 @@ public class TestQueryDetails {
         QueryDetails d = QueryDetails.parseQueryDetails("CREATE TABLE x (c1 VARCHAR)");
         assertEquals(Collections.emptySet(), d.getFromTables());
         assertEquals(Collections.emptySet(), d.getAliasTables());
-        assertEquals( "x", d.getTargetTable());
-        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("x", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
         assertEquals("CreateTable", d.getOperation());
     }
 
@@ -86,8 +86,8 @@ public class TestQueryDetails {
         QueryDetails d = QueryDetails.parseQueryDetails("CREATE TABLE x AS SELECT * FROM y");
         assertEquals(newHashSet("y"), d.getFromTables());
         assertEquals(Collections.emptySet(), d.getAliasTables());
-        assertEquals( "x", d.getTargetTable());
-        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("x", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
         assertEquals("CreateTableAsSelect", d.getOperation());
     }
 
@@ -96,8 +96,8 @@ public class TestQueryDetails {
         QueryDetails d = QueryDetails.parseQueryDetails("CREATE VIEW x AS SELECT * FROM y");
         assertEquals(newHashSet("y"), d.getFromTables());
         assertEquals(Collections.emptySet(), d.getAliasTables());
-        assertEquals( "x", d.getTargetTable());
-        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("x", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
         assertEquals("CreateView", d.getOperation());
     }
 
@@ -106,8 +106,8 @@ public class TestQueryDetails {
         QueryDetails d = QueryDetails.parseQueryDetails("DROP TABLE x");
         assertEquals(Collections.emptySet(), d.getFromTables());
         assertEquals(Collections.emptySet(), d.getAliasTables());
-        assertEquals( "x", d.getTargetTable());
-        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("x", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
         assertEquals("DropTable", d.getOperation());
     }
 
@@ -116,8 +116,8 @@ public class TestQueryDetails {
         QueryDetails d = QueryDetails.parseQueryDetails("DROP VIEW x");
         assertEquals(Collections.emptySet(), d.getFromTables());
         assertEquals(Collections.emptySet(), d.getAliasTables());
-        assertEquals( "x", d.getTargetTable());
-        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("x", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
         assertEquals("DropView", d.getOperation());
     }
 
@@ -126,8 +126,8 @@ public class TestQueryDetails {
         QueryDetails d = QueryDetails.parseQueryDetails("SELECT 100.0");
         assertEquals(Collections.emptySet(), d.getFromTables());
         assertEquals(Collections.emptySet(), d.getAliasTables());
-        assertEquals( "", d.getTargetTable());
-        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("", d.getTargetTable());
+        assertEquals(Collections.emptySet(), d.getCTETables());
         assertEquals("Query", d.getOperation());
     }
 }

--- a/src/test/java/com/shopify/presto/eventlistener/TestQueryDetails.java
+++ b/src/test/java/com/shopify/presto/eventlistener/TestQueryDetails.java
@@ -120,4 +120,14 @@ public class TestQueryDetails {
         assertEquals( Collections.emptySet(), d.getCTETables());
         assertEquals("DropView", d.getOperation());
     }
+
+    @Test
+    public void testDecimalLiteral() {
+        QueryDetails d = QueryDetails.parseQueryDetails("SELECT 100.0");
+        assertEquals(Collections.emptySet(), d.getFromTables());
+        assertEquals(Collections.emptySet(), d.getAliasTables());
+        assertEquals( "", d.getTargetTable());
+        assertEquals( Collections.emptySet(), d.getCTETables());
+        assertEquals("Query", d.getOperation());
+    }
 }


### PR DESCRIPTION
Literally the only parsing option, and we use a non-standard value on our cluster :/

This should resolve the bulk of the query parsing issues, so we can log detail about all queries.